### PR TITLE
hide http gremlin server console out

### DIFF
--- a/docker/dynamodb-janusgraph/run.sh
+++ b/docker/dynamodb-janusgraph/run.sh
@@ -55,5 +55,5 @@ function run_janus_http {
 
 
 run_awslogs
-run_janus_http &  # in background for ALB health check
+run_janus_http &> /dev/null &  # in background for ALB health check
 run_janus


### PR DESCRIPTION
to avoid a lots of console output which make debugging more difficult Also, because we use http gremlin server as a workaround for health check only.